### PR TITLE
Fix append issue in mpc_stat.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ proc_loop.*
 .pydevproject
 .settings
 *.json
+test
+venv

--- a/makepages/StationMPECGraph.py
+++ b/makepages/StationMPECGraph.py
@@ -507,6 +507,13 @@ def createGraph(station_code, includeFirstFU = True):
                 </thead>
                 <tbody>"""
     for observer, count in mpec_data[station[-3::]]['OBS'].items():
+        # Check if the observer string starts with a comma or comma followed by a space and remove it
+        if observer.startswith(", "):
+            observer = observer[2:]
+            print(station[-3::], observer)
+        elif observer.startswith(","):
+            observer = observer[1:]
+            print(station[-3::], observer)
         o += """
                     <tr>
                         <td>{}</td>
@@ -532,6 +539,12 @@ def createGraph(station_code, includeFirstFU = True):
                 <tbody>"""
     
     for measurer, count in mpec_data[station[-3::]]['MEA'].items():
+        if measurer.startswith(", "):
+            measurer = measurer[2:]
+            print(station[-3::], measurer)
+        elif measurer.startswith(","):
+            measurer = measurer[1:]
+            print(station[-3::], measurer)
         o += """
                     <tr>
                         <td>{}</td>

--- a/makepages/mpc_stat.py
+++ b/makepages/mpc_stat.py
@@ -87,8 +87,8 @@ for y in np.arange(1993, currentYear+1, 1):
                 stat_issuer[issuer][str(y)] = r[matched[0][0]][1]
                 issuer_nmpec_thisyear.append(r[matched[0][0]][1])
         
-    df_computer = df_computer.append(pd.DataFrame({"Year": [y]*len(list_computer), "Orbit computer": list_computer, "#MPECs": computer_nmpec_thisyear}), ignore_index = True)
-    df_issuer = df_issuer.append(pd.DataFrame({"Year": [y]*len(list_issuer), "Issuer": list_issuer, "#MPECs": issuer_nmpec_thisyear}), ignore_index = True)
+    df_computer = pd.concat([df_computer, pd.DataFrame({"Year": [y]*len(list_computer), "Orbit computer": list_computer, "#MPECs": computer_nmpec_thisyear})], ignore_index = True)
+    df_issuer = pd.concat([df_issuer, pd.DataFrame({"Year": [y]*len(list_issuer), "Issuer": list_issuer, "#MPECs": issuer_nmpec_thisyear})], ignore_index = True)
     
 fig = px.bar(df_computer, x="Year", y="#MPECs", color="Orbit computer", title="Number MPECs by orbit computers")
 fig.write_html("../www/Computer_ByYear_Fig.html")  
@@ -168,8 +168,8 @@ for mt in ['Discovery', 'OrbitUpdate']:
                     stat_issuer[issuer][str(y)] = r[matched[0][0]][1]
                     issuer_nmpec_thisyear.append(r[matched[0][0]][1])
             
-        df_computer = df_computer.append(pd.DataFrame({"Year": [y]*len(list_computer), "Orbit computer": list_computer, "#MPECs": computer_nmpec_thisyear}), ignore_index = True)
-        df_issuer = df_issuer.append(pd.DataFrame({"Year": [y]*len(list_issuer), "Issuer": list_issuer, "#MPECs": issuer_nmpec_thisyear}), ignore_index = True)
+        df_computer = pd.concat([df_computer, pd.DataFrame({"Year": [y]*len(list_computer), "Orbit computer": list_computer, "#MPECs": computer_nmpec_thisyear})], ignore_index = True)
+        df_issuer = pd.concat([df_issuer, pd.DataFrame({"Year": [y]*len(list_issuer), "Issuer": list_issuer, "#MPECs": issuer_nmpec_thisyear})], ignore_index = True)
         
     fig = px.bar(df_computer, x="Year", y="#MPECs", color="Orbit computer", title="Number MPECs by orbit computers")
     fig.write_html("../www/Computer_%s_ByYear_Fig.html" % mt)  


### PR DESCRIPTION
updating depreciated pandas append to concat function results in a new error which is current being worked on:
Traceback (most recent call last):
  File "d:\mpec_files\mpecwatch\makepages\mpc_stat.py", line 214, in <module>
    editorial = len(np.where((tmp.T[0] == h) & (tmp.T[2] == 'Editorial'))[0])
                              ~~~~~^^^
IndexError: index 0 is out of bounds for axis 0 with size 0